### PR TITLE
Fix issue of page navigating back when pressing backspace [mac]

### DIFF
--- a/static/js/comicmachine.js
+++ b/static/js/comicmachine.js
@@ -258,7 +258,13 @@ fabric.Object.prototype.set({
     window.addEventListener("keydown", function(e){
 	// Allow use of backspace or delete key to delete objects
 	if(e.keyCode === 8 || e.keyCode === 46) {
-            e.preventDefault();
+
+            if(e.keyCode==8){
+                if(e.target==document.body){
+                    e.preventDefault();
+                    return false;
+                }
+            }
             canvas.remove(canvas.getActiveObject());
 	}
     });

--- a/static/js/comicmachine.js
+++ b/static/js/comicmachine.js
@@ -258,6 +258,7 @@ fabric.Object.prototype.set({
     window.addEventListener("keydown", function(e){
 	// Allow use of backspace or delete key to delete objects
 	if(e.keyCode === 8 || e.keyCode === 46) {
+            e.preventDefault();
             canvas.remove(canvas.getActiveObject());
 	}
     });


### PR DESCRIPTION
Fixes #51 .

Reproduce: happens when _Chali Machine_ is not the first page. i.e browser has a page to go back to.
Cause : not calling `e.preventDefault();`
